### PR TITLE
Update dependencies with known vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <io.rsocket.version>1.1.0</io.rsocket.version>
+    <io.rsocket.version>1.1.1</io.rsocket.version>
     <io.projectreactor.bom.version>2020.0.6</io.projectreactor.bom.version>
     <io.projectreactor.version>3.4.5</io.projectreactor.version>
     <io.projectreactor.extra.version>3.4.3</io.projectreactor.extra.version>
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.1.52.Final</version>
+      <version>4.1.65.Final</version>
     </dependency>
     <dependency>
       <groupId>io.rsocket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <io.rsocket.version>1.1.1</io.rsocket.version>
-    <io.projectreactor.bom.version>2020.0.6</io.projectreactor.bom.version>
-    <io.projectreactor.version>3.4.5</io.projectreactor.version>
+    <io.projectreactor.bom.version>2020.0.8</io.projectreactor.bom.version>
+    <io.projectreactor.version>3.4.7</io.projectreactor.version>
     <io.projectreactor.extra.version>3.4.3</io.projectreactor.extra.version>
     <graalvm.version>21.1.0</graalvm.version>
   </properties>
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION

```
netty-all-4.1.52.Final.jar (pkg:maven/io.netty/netty-all@4.1.52.Final, cpe:2.3:a:netty:netty:4.1.52:*:*:*:*:*:*:*) : CVE-2021-21290, CVE-2021-21295, CVE-2021-21409
netty-transport-4.1.53.Final.jar (pkg:maven/io.netty/netty-transport@4.1.53.Final, cpe:2.3:a:netty:netty:4.1.53:*:*:*:*:*:*:*) : CVE-2021-21290, CVE-2021-21295, CVE-2021-21409
```